### PR TITLE
Update .gitignore to Exclude *.synctex.gz Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.log
 *.out
 *.pdf
+*.synctex.gz


### PR DESCRIPTION
`*.synctex.gz` files are typically generated when compiling LaTeX documents. These files do not need to be tracked by Git.