### PR TITLE
BabyRudin: define a newcommand to include files

### DIFF
--- a/Books/BabyRudin/BabyRudin.tex
+++ b/Books/BabyRudin/BabyRudin.tex
@@ -2,16 +2,36 @@
 
 \usepackage{amsmath}
 \usepackage{amsfonts}
+\usepackage{pgffor}   % sudo apt install texlive-latex-extra
 \usepackage{hyperref}
 
-\title{Solution to Exercises on the \\Principles of Mathematical Analysis}
+\newcommand{\inputfiles}[2]{
+    \def\filename{#1}
+    \def\totalexercises{1,...,#2}
+    \def\authorname{cecilia,gapry}
+    \foreach \i in \totalexercises {
+        \IfFileExists{\filename\i.tex} {
+            \input{\filename\i.tex}
+        }{
+            \foreach \j in \authorname{
+                \IfFileExists{\filename\i.\j.tex}{
+                    \input{\filename\i.\j.tex}
+                }
+            }
+        }
+    }
+}
+
+\title{Solution to Exercises on the \\Principles of Mathematical Analysis (3rd)}
+\author{Cecilia, Gapry}
 
 \begin{document}
 \maketitle
 
 \section*{Ch01 - The Real and Complex Number Systems}
-\input{Chapter01/ex01.tex}
-\input{Chapter01/ex08.cecilia.tex}
-\input{Chapter01/ex08.gapry.tex}
+\inputfiles{Chapter01/ex0}{20}
+
+\section*{Ch02 - Basic Topology}
+\inputfiles{Chapter02/ex0}{30}
 
 \end{document}


### PR DESCRIPTION
This Pull Request introduces a solution to prevent merge conflicts and enhance the flexibility of included files.

When an exercise is solved, the Pull Request would typically look like this:
```latex
+\section*{Ch01 - The Real and Complex Number Systems}
+\input{Chapter01/ex01.tex}
```

However, if another exercise is solved, the Pull Request might look like this:
```latex
+\section*{Ch01 - The Real and Complex Number Systems}
+\input{Chapter01/ex02.tex}
```

This situation could lead to merge conflicts. To address this issue, a `newcommand` is defined as follows:
```latex
\newcommand{\inputfiles}[2]{
    \def\filename{#1}
    \def\totalexercises{1,...,#2}
    \def\authorname{cecilia,gapry}
    \foreach \i in \totalexercises {
        \IfFileExists{\filename\i.tex} {
            \input{\filename\i.tex}
        }{
            \foreach \j in \authorname{
                \IfFileExists{\filename\i.\j.tex}{
                    \input{\filename\i.\j.tex}
                }
            }
        }
    }
}
```

The `\newcommand{\inputfiles}[2]{...}` is a custom LaTeX command. It takes two arguments: the prefix of the exercise files and the total number of exercises. It checks for the existence of each exercise file and inputs it if found. If not, it checks for author-specific versions of the file and inputs those if found. 

The usage of this `newcommand` is straightforward. Simply provide the prefix of the exercises and the total number of exercises as shown below:
```latex
\inputfiles{Chapter01/ex0}{20}
\inputfiles{Chapter02/ex0}{30}
```
